### PR TITLE
show #lang dan-scheme in the docs

### DIFF
--- a/scribblings/dan-scheme.scrbl
+++ b/scribblings/dan-scheme.scrbl
@@ -5,10 +5,10 @@
 @title{Dan Scheme}
 @author{David Christiansen}
 
-@defmodule[dan-scheme]
-
+@defmodulelang[dan-scheme]{
 This is a little Scheme-like language for situations in which
 simplicity is preferred over convenience.
+}
 
 @local-table-of-contents[]
 


### PR DESCRIPTION
Using `defmodulelang`:
- changes how `dan-scheme` appears in search results (as "`dan-scheme` language")
- puts `#lang dan-scheme` at the top of the documentation page

To see the changes to the search page, checkout the branch & run `raco setup --doc-index dan-scheme`.