### PR TITLE
propagate source locations in error messages

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection "dan-scheme")
 (define version "0.1")
-(define deps '("base"))
+(define deps '("base" "rackunit-lib"))
 (define build-deps '("scribble-lib" "racket-doc"))
 (define scribblings '(("scribblings/dan-scheme.scrbl" ())))
 (define pkg-desc "A very little language for situations where simplicity is desired over convenience")


### PR DESCRIPTION
Changes:
- runtime errors print their line number
- `dan-define` and `dan-lambda` attach the correct source locations
- added a fancy-and-brittle macro to test that error messages
  give approximately the right source location